### PR TITLE
vring: fix potential out-of-bounds issue

### DIFF
--- a/include/libvhost_internal.h
+++ b/include/libvhost_internal.h
@@ -28,7 +28,6 @@
 #define wmb() asm volatile("dmb ishst" : : : "memory")
 #endif
 
-#define VIRTIO_MAX_IODEPTH 256
 struct vhost_inflight {
     int fd;
     void* addr;
@@ -107,10 +106,13 @@ struct libvhost_virt_queue {
     uint16_t free_head;
     uint16_t num_free;
 
-    struct libvhost_io_task tasks[VIRTIO_MAX_IODEPTH];
-    void* desc_state[VIRTIO_MAX_IODEPTH];
+    struct libvhost_io_task *tasks;
+    void **desc_state;
+    struct libvhost_io_task **done_tasks;
 };
 
+int vring_alloc_state_extra(struct libvhost_virt_queue* vq);
+void vring_free_state_extra(struct libvhost_virt_queue* vq);
 void vhost_vq_init(struct libvhost_virt_queue* vq, struct libvhost_ctrl* ctrl);
 void virtring_add(struct libvhost_virt_queue* vq, struct iovec* iovec, int num_out, int num_in, void* data);
 struct libvhost_io_task* virtring_get_free_task(struct libvhost_virt_queue* vq);

--- a/lib/ctrl.c
+++ b/lib/ctrl.c
@@ -255,6 +255,9 @@ void libvhost_ctrl_destroy(struct libvhost_ctrl* ctrl) {
         pthread_join(ctrl->thread, NULL);
     }
     close(ctrl->sock);
+    for (int i = 0; i < ctrl->nr_vqs; ++i) {
+        vring_free_state_extra(&ctrl->vqs[i]);
+    }
     __ctrl_free_memory(ctrl);
     free(ctrl->sock_path);
     free(ctrl->vqs);
@@ -677,6 +680,9 @@ int libvhost_ctrl_add_virtqueue(struct libvhost_ctrl* ctrl, int num_io_queues, i
         vq->idx = i;
         vq->size = size;
         vhost_vq_init(vq, ctrl);
+        if ((ret = vring_alloc_state_extra(vq)) != 0) {
+            return ret;
+        }
         if ((ret = vhost_enable_vq(ctrl, vq)) != 0) {
             return ret;
         }

--- a/lib/io.c
+++ b/lib/io.c
@@ -232,10 +232,14 @@ int libvhost_submit(struct libvhost_ctrl* ctrl, int q_idx, uint64_t offset, stru
 int libvhost_getevents(struct libvhost_ctrl* ctrl, int q_idx, int nr, VhostEvent* events) {
     int done = 0;
     int ret = 0;
+    int q_size = 0;
     int i;
-    struct libvhost_io_task* done_tasks[VIRTIO_MAX_IODEPTH];
+    struct libvhost_io_task** done_tasks;
 
     q_idx = ctrl->type == DEVICE_TYPE_BLK ? q_idx : q_idx + 2;
+    q_size = ctrl->vqs[q_idx].size;
+    done_tasks = ctrl->vqs[q_idx].done_tasks;
+    memset(done_tasks, 0, q_size * sizeof(struct libvhost_io_task*));
 
     while (done < nr) {
         ret = task_getevents(&ctrl->vqs[q_idx], &done_tasks[done]);


### PR DESCRIPTION
Struct libvhost_virt_queue's members desc_state and tasks should not be fixed-length arrays cuz the vring size is uncertain.

If the vring size is greater than the fixed-length, it would be occur out-of-bounds when virtring_add.

It is a very confusing memory issue.