### PR TITLE
vring: fix potential out-of-bounds issue

### DIFF
--- a/include/libvhost_internal.h
+++ b/include/libvhost_internal.h
@@ -108,10 +108,11 @@ struct libvhost_virt_queue {
     uint16_t num_free;
 
     struct libvhost_io_task tasks[VIRTIO_MAX_IODEPTH];
-    void* desc_state[VIRTIO_MAX_IODEPTH];
+    void** desc_state;
 };
 
 void vhost_vq_init(struct libvhost_virt_queue* vq, struct libvhost_ctrl* ctrl);
+void vhost_vq_free(struct libvhost_virt_queue* vq);
 void virtring_add(struct libvhost_virt_queue* vq, struct iovec* iovec, int num_out, int num_in, void* data);
 struct libvhost_io_task* virtring_get_free_task(struct libvhost_virt_queue* vq);
 void virtring_free_task(struct libvhost_io_task* task);

--- a/lib/ctrl.c
+++ b/lib/ctrl.c
@@ -249,6 +249,8 @@ static void __ctrl_free_memory(struct libvhost_ctrl* ctrl) {
 }
 
 void libvhost_ctrl_destroy(struct libvhost_ctrl* ctrl) {
+    int i;
+
     // TODO: use load and store to make it thread safe.
     ctrl->stopped = true;
     if (ctrl->thread) {
@@ -257,6 +259,9 @@ void libvhost_ctrl_destroy(struct libvhost_ctrl* ctrl) {
     close(ctrl->sock);
     __ctrl_free_memory(ctrl);
     free(ctrl->sock_path);
+    for (i = 0; i < ctrl->nr_vqs; ++i){
+        vhost_vq_free(&ctrl->vqs[i]);
+    }
     free(ctrl->vqs);
     if (ctrl->type == DEVICE_TYPE_BLK) {
         free(ctrl->blk_config);

--- a/lib/virtqueue.c
+++ b/lib/virtqueue.c
@@ -29,7 +29,6 @@ void vhost_vq_init(struct libvhost_virt_queue* vq, struct libvhost_ctrl* ctrl) {
     uint64_t total_size;
     uint64_t size_aligned;
     void* q_mem;
-    void* q_mem_align;
     int i;
 
     CHECK(ctrl);
@@ -38,6 +37,8 @@ void vhost_vq_init(struct libvhost_virt_queue* vq, struct libvhost_ctrl* ctrl) {
 
     vq->kickfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
     vq->callfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+
+    vq->desc_state = calloc(sizeof(void*), vq->size);
 
     size_aligned = vring_size(vq->size, VIRTIO_PCI_VRING_ALIGN);
     q_mem = libvhost_malloc(ctrl, size_aligned);
@@ -49,6 +50,13 @@ void vhost_vq_init(struct libvhost_virt_queue* vq, struct libvhost_ctrl* ctrl) {
         vq->vring.desc[i].next = i + 1;
     }
     vq->vring.desc[i].next = 0;
+}
+
+
+void vhost_vq_free(struct libvhost_virt_queue* vq) {
+    free(vq->desc_state);
+    close(vq->kickfd);
+    close(vq->callfd);
 }
 
 static void virtio_get_flags_name(uint16_t flags, char name[16]) {


### PR DESCRIPTION
Struct libvhost_virt_queue's members desc_state should be equal to vring size instead of the fixed-length.

If the vring size is greater than the fixed-length, it would be occur out-of-bounds when virtring_add.

It is a very confusing memory issue.