### PR TITLE
vring: support indirect-vring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # TODO
 - [x] 大页内存退出时不释放
 - [ ] virtio
-    - [ ] indirect desc support
+    - [x] indirect desc support
     - [ ] packed ring support
     - [ ] interrupt io(eventfd) support
 - [ ] kernel vhost-scsi support
@@ -10,6 +10,6 @@
 - [x] 获取后端设备的 block size 和 长度
 - [ ] 检测后端设备是 vhost-blk 或者 vhost-scsi
 - [x] 支持 vhost-user-scsi
-- [ ] 支持后端重启后重连
+- [x] 支持后端重启后重连
 - [ ] 重写内存分配器
 

--- a/examples/main.c
+++ b/examples/main.c
@@ -152,7 +152,7 @@ int test_async_io(struct libvhost_ctrl* ctrl) {
     int idx;
     int ret = 0;
     int buf_size = 1024;
-    const int depth = 128;
+    const int depth = 1024;
     const int max_round = 100;
     struct test_iov r_iov[depth];
     struct test_iov w_iov[depth];
@@ -206,6 +206,12 @@ static int test_blk(struct libvhost_ctrl* ctrl) {
         return ret;
     }
 
+    ret = test_async_io(ctrl);
+    if (ret != 0) {
+        printf("vhost-blk async io failed\n");
+        return ret;
+    }
+
     ret = test_discard(ctrl);
     if (ret != 0) {
         printf("test_discard failed: %d\n", ret);
@@ -240,7 +246,11 @@ static int test_scsi(struct libvhost_ctrl* ctrl) {
     }
     printf("vhost-scsi sync read write ok\n");
 
-    test_async_io(ctrl);
+    ret = test_async_io(ctrl);
+    if (ret != 0) {
+        printf("vhost-scsi async io failed\n");
+        goto fail;
+    }
     printf("vhost-scsi async io ok\n");
 
 fail:

--- a/include/libvhost_internal.h
+++ b/include/libvhost_internal.h
@@ -99,6 +99,7 @@ struct libvhost_virt_queue {
     int size;
     /* Must be [0, 2^16 - 1] */
     uint16_t last_used_idx;
+    bool indirect;
     int kickfd;
     int callfd;
 


### PR DESCRIPTION
With this patch, libvhost would use indirect vring by default.